### PR TITLE
Remove public constructor requirement

### DIFF
--- a/Immutable.Net/Immutable.Net/Immutable.cs
+++ b/Immutable.Net/Immutable.Net/Immutable.cs
@@ -17,7 +17,7 @@ namespace ImmutableNet
         /// <typeparam name="T">The type to enclose.</typeparam>
         /// <param name="self">The instance to create the Immutable from.</param>
         /// <returns>A new Immutable with a cloned enclosed instance.</returns>
-        public static Immutable<T> Create<T>(T self) where T : new()
+        public static Immutable<T> Create<T>(T self) where T : class
         {
             return Immutable<T>.Create(self);
         }

--- a/Immutable.Net/Immutable.Net/ImmutableBuilder.cs
+++ b/Immutable.Net/Immutable.Net/ImmutableBuilder.cs
@@ -16,7 +16,7 @@ namespace ImmutableNet
         /// </summary>
         /// <param name="self">The instance of the enclosed type to use.</param>
         /// <returns>A new ImmutableBuilder instance.</returns>
-        public static ImmutableBuilder<T> Create<T>(T self) where T : new()
+        public static ImmutableBuilder<T> Create<T>(T self) where T : class
         {
             return ImmutableBuilder<T>.Create(self);
         }

--- a/Immutable.Net/Immutable.Net/ImmutableBuilder`T.cs
+++ b/Immutable.Net/Immutable.Net/ImmutableBuilder`T.cs
@@ -13,7 +13,7 @@ namespace ImmutableNet
     /// to build an Immutable.
     /// </summary>
     /// <typeparam name="T">The enclosed type of the ImmutableBuilder.</typeparam>
-    public class ImmutableBuilder<T> where T : new()
+    public class ImmutableBuilder<T> where T : class
     {
         /// <summary>
         /// An instance of the enclosed type.
@@ -35,7 +35,7 @@ namespace ImmutableNet
         /// </summary>
         public ImmutableBuilder() 
         {
-            this.self = new T();
+            this.self = Activator.CreateInstance<T>();
         }
 
         /// <summary>

--- a/Immutable.Net/Immutable.Net/Immutable`T.cs
+++ b/Immutable.Net/Immutable.Net/Immutable`T.cs
@@ -16,7 +16,7 @@ namespace ImmutableNet
     /// <typeparam name="T">The type to enclose.</typeparam>
     [Serializable]
     [XmlType]
-    public class Immutable<T> : ISerializable where T : new()
+    public class Immutable<T> : ISerializable where T : class
     {
         /// <summary>
         /// An instance of the enclosed immutable data type.
@@ -59,7 +59,7 @@ namespace ImmutableNet
         /// </summary>
         public Immutable() 
         {
-            self = new T();
+            self = Activator.CreateInstance<T>();
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace ImmutableNet
         /// <param name="context">The serialization streaming context.</param>
         private Immutable(SerializationInfo info, StreamingContext context)
         {
-            self = new T();
             if(deserializationDelegate == null)
+            self = Activator.CreateInstance<T>();
             {
                 deserializationDelegate = DelegateBuilder.BuildDeserializationDelegate<T>();
             }


### PR DESCRIPTION
Instead, use Activator.CreateInstance<>.

Solves Issue #1.
