### PR TITLE
Remove public constructor requirement

### DIFF
--- a/Immutable.Net/Immutable.Net.Tests/ImmutableTests.cs
+++ b/Immutable.Net/Immutable.Net.Tests/ImmutableTests.cs
@@ -46,6 +46,13 @@ namespace ImmutableNet.Tests
             public int? Nullable { get; set; }
         }
 
+        class TestClassWithPrivateConstructor
+        {
+            private TestClassWithPrivateConstructor()
+            {
+            }
+        }
+
         [Fact]
         public void Test_That_Original_Object_Cannot_Be_Modified()
         {
@@ -234,6 +241,18 @@ namespace ImmutableNet.Tests
             testClass = testClass.Modify(x => x.Nullable, testDecimal);
 
             Assert.Null(testClass.Get(x => x.Nullable));
+        }
+
+        [Fact]
+        public void Test_That_Object_Can_Have_Private_Constructor()
+        {
+            Assert.DoesNotThrow(() => new Immutable<TestClassWithPrivateConstructor>());
+        }
+
+        [Fact]
+        public void Test_That_ImmutableBuilder_Object_Can_Have_Private_Constructor()
+        {
+            Assert.DoesNotThrow(() => new ImmutableBuilder<TestClassWithPrivateConstructor>());
         }
     }
 }

--- a/Immutable.Net/Immutable.Net/DelegateBuilder.cs
+++ b/Immutable.Net/Immutable.Net/DelegateBuilder.cs
@@ -147,5 +147,10 @@ namespace ImmutableNet
             var block = Expression.Block(expressionList);
             return Expression.Lambda<Func<T, SerializationInfo, T>>(block, new ParameterExpression[] { thisObject, serializationInfo }).Compile();
         }
+
+        internal static Func<T> BuildCreationDelegate<T>()
+        {
+            return Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
+        } 
     }
 }

--- a/Immutable.Net/Immutable.Net/Immutable.cs
+++ b/Immutable.Net/Immutable.Net/Immutable.cs
@@ -17,7 +17,7 @@ namespace ImmutableNet
         /// <typeparam name="T">The type to enclose.</typeparam>
         /// <param name="self">The instance to create the Immutable from.</param>
         /// <returns>A new Immutable with a cloned enclosed instance.</returns>
-        public static Immutable<T> Create<T>(T self) where T : new()
+        public static Immutable<T> Create<T>(T self) where T : class
         {
             return Immutable<T>.Create(self);
         }

--- a/Immutable.Net/Immutable.Net/ImmutableBuilder.cs
+++ b/Immutable.Net/Immutable.Net/ImmutableBuilder.cs
@@ -16,7 +16,7 @@ namespace ImmutableNet
         /// </summary>
         /// <param name="self">The instance of the enclosed type to use.</param>
         /// <returns>A new ImmutableBuilder instance.</returns>
-        public static ImmutableBuilder<T> Create<T>(T self) where T : new()
+        public static ImmutableBuilder<T> Create<T>(T self) where T : class
         {
             return ImmutableBuilder<T>.Create(self);
         }

--- a/Immutable.Net/Immutable.Net/ImmutableBuilder`T.cs
+++ b/Immutable.Net/Immutable.Net/ImmutableBuilder`T.cs
@@ -13,12 +13,17 @@ namespace ImmutableNet
     /// to build an Immutable.
     /// </summary>
     /// <typeparam name="T">The enclosed type of the ImmutableBuilder.</typeparam>
-    public class ImmutableBuilder<T> where T : new()
+    public class ImmutableBuilder<T> where T : class
     {
         /// <summary>
         /// An instance of the enclosed type.
         /// </summary>
         private T self;
+
+        /// <summary>
+        /// A cached delegate that calls a parameterless constructor.
+        /// </summary>
+        private static Func<T> creationDelegate;
 
         /// <summary>
         /// Creates a new Immutable builder with the supplied enclosed type instance.
@@ -35,7 +40,12 @@ namespace ImmutableNet
         /// </summary>
         public ImmutableBuilder() 
         {
-            this.self = new T();
+            if (creationDelegate == null)
+            {
+                creationDelegate = DelegateBuilder.BuildCreationDelegate<T>();
+            }
+
+            self = creationDelegate.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
Instead, use cached delegate for constructor call.
