### PR TITLE
Make delegate cache shared b/w Immutable & Builder

### DIFF
--- a/Immutable.Net/Immutable.Net/DelegateCache`T.cs
+++ b/Immutable.Net/Immutable.Net/DelegateCache`T.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace ImmutableNet
+{
+    /// <summary>
+    /// An internal caching class that holds delegates for manipulating immutables.
+    /// </summary>
+    /// <typeparam name="T">The enclosed type of the immutable</typeparam>
+    internal static class DelegateCache<T>
+    {
+        /// <summary>
+        /// An internal caching class that holds a cache of immutable accessor delegates.
+        /// </summary>
+        /// <typeparam name="TValue">The property type for this accessor.</typeparam>
+        internal static class Accessor<TValue>
+        {
+            /// <summary>
+            /// Holds a dictionary of possible delegates for caching. Because a given
+            /// immutable type may have multiple properties of the same type, the delegates
+            /// must be differentiated here by MemberInfo.
+            /// </summary>
+            internal static readonly ConcurrentDictionary<MemberInfo, Func<T, TValue, T>> AccessorDelegates = new ConcurrentDictionary<MemberInfo, Func<T, TValue, T>>();
+        }
+
+        /// <summary>
+        /// A cached delegate that clones the enclosed type.
+        /// </summary>
+        internal static Func<T, T> CloneDelegate;
+
+        /// <summary>
+        /// A cached delegate that calls a parameterless constructor.
+        /// </summary>
+        internal static Func<T> CreationDelegate;
+
+        /// <summary>
+        /// A cached delegate that serializes the enclosed type.
+        /// </summary>
+        internal static Func<T, SerializationInfo, T> SerializationDelegate;
+
+        /// <summary>
+        /// A cached delegate that deserializes the enclosed type.
+        /// </summary>
+        internal static Func<T, SerializationInfo, T> DeserializationDelegate;
+    }
+}

--- a/Immutable.Net/Immutable.Net/Immutable.Net.csproj
+++ b/Immutable.Net/Immutable.Net/Immutable.Net.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DelegateBuilder.cs" />
+    <Compile Include="DelegateCache`T.cs" />
     <Compile Include="Immutable.cs" />
     <Compile Include="ImmutableBuilder.cs" />
     <Compile Include="Immutable`T.cs" />

--- a/Immutable.Net/Immutable.Net/ImmutableBuilder`T.cs
+++ b/Immutable.Net/Immutable.Net/ImmutableBuilder`T.cs
@@ -21,11 +21,6 @@ namespace ImmutableNet
         private T self;
 
         /// <summary>
-        /// A cached delegate that calls a parameterless constructor.
-        /// </summary>
-        private static Func<T> creationDelegate;
-
-        /// <summary>
         /// Creates a new Immutable builder with the supplied enclosed type instance.
         /// </summary>
         /// <param name="self">The instance of the enclosed type to use.</param>
@@ -40,12 +35,12 @@ namespace ImmutableNet
         /// </summary>
         public ImmutableBuilder() 
         {
-            if (creationDelegate == null)
+            if (DelegateCache<T>.CreationDelegate == null)
             {
-                creationDelegate = DelegateBuilder.BuildCreationDelegate<T>();
+                DelegateCache<T>.CreationDelegate = DelegateBuilder.BuildCreationDelegate<T>();
             }
 
-            self = creationDelegate.Invoke();
+            self = DelegateCache<T>.CreationDelegate.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
`Immutable` and `ImmutableBuilder` each had their own cached creation delegate. This PR extracts the cache so the delegate can be shared and compiled only once.
