### PR TITLE
The bug that caused the user to change the state has been fixed.

### DIFF
--- a/src/ImmutableDotNet/Immutable`T.cs
+++ b/src/ImmutableDotNet/Immutable`T.cs
@@ -108,11 +108,11 @@ namespace ImmutableNet
         /// Gets a value from the Immutable.
         /// </summary>
         /// <typeparam name="TReturn">The type of the value to return.</typeparam>
-        /// <param name="accessor">A lambda containing the member to return.</param>
+        /// <param name="accessor">A lambda expression containing the member to return.</param>
         /// <returns>A value from the provided member.</returns>
-        public TReturn Get<TReturn>(Func<T, TReturn> accessor)
+        public TReturn Get<TReturn>(Expression<Func<T, TReturn>> accessor)
         {
-            return accessor(_self);
+            return accessor.Compile()(_self);
         }
 
         /// <summary>

--- a/src/ImmutableDotNet/Immutable`T.cs
+++ b/src/ImmutableDotNet/Immutable`T.cs
@@ -113,7 +113,7 @@ namespace ImmutableNet
         public TReturn Get<TReturn>(Expression<Func<T, TReturn>> accessor)
         {
             var prop = (PropertyInfo)((MemberExpression)accessor.Body).Member;
-            return (TReturn)prop.GetValue(accessor);
+            return (TReturn)prop.GetValue(_self);
         }
 
         /// <summary>

--- a/src/ImmutableDotNet/Immutable`T.cs
+++ b/src/ImmutableDotNet/Immutable`T.cs
@@ -112,7 +112,8 @@ namespace ImmutableNet
         /// <returns>A value from the provided member.</returns>
         public TReturn Get<TReturn>(Expression<Func<T, TReturn>> accessor)
         {
-            return accessor.Compile()(_self);
+            var prop = (PropertyInfo)((MemberExpression)accessor.Body).Member;
+            return (TReturn)prop.GetValue(accessor);
         }
 
         /// <summary>


### PR DESCRIPTION
There is an issue on `Get<TResult>` method.

The original 
``` 
var customerName = order.Get(x => x.CustomerName);
```
method could be hacked like this:
``` 
var customerName = order.Get(x => {x.CustomerName = "Cihan"; return  "Cihan"});
// now, state is changed and order.Get(x => x.CustomerName) will returns "Cihan"
```
