### PR TITLE
Integration with older JSON.Net versions and protobuf-net compatibility

### DIFF
--- a/src/ImmutableDotNet.Serialization.Newtonsoft/ImmutableDotNet.Serialization.Newtonsoft.csproj
+++ b/src/ImmutableDotNet.Serialization.Newtonsoft/ImmutableDotNet.Serialization.Newtonsoft.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Immutable.Net.Serialization.Newtonsoft</PackageId>
     <Authors>Matt Nischan</Authors>
@@ -11,10 +11,18 @@
     <Copyright>Apache 2.0</Copyright>
     <PackageProjectUrl>https://github.com/mattnischan/Immutable.Net</PackageProjectUrl>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0.html</PackageLicenseUrl>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/src/ImmutableDotNet/Immutable`T.cs
+++ b/src/ImmutableDotNet/Immutable`T.cs
@@ -21,7 +21,7 @@ namespace ImmutableNet
         /// <summary>
         /// An instance of the enclosed immutable data type.
         /// </summary>
-        [DataMember]
+        [DataMember(Order = 1)]
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         private T _self;
 

--- a/tests/ImmutableDotNet.Tests/ImmutableDotNet.Tests.csproj
+++ b/tests/ImmutableDotNet.Tests/ImmutableDotNet.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="protobuf-net" Version="2.1.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tests/ImmutableDotNet.Tests/ImmutableTests.cs
+++ b/tests/ImmutableDotNet.Tests/ImmutableTests.cs
@@ -1,8 +1,10 @@
 ﻿using ImmutableDotNet.Serialization.Newtonsoft;
 using Newtonsoft.Json;
+using ProtoBuf;
 using Shouldly;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Text;
 using Xunit;
 
@@ -40,10 +42,13 @@ namespace ImmutableNet.Tests
             }
         }
 
+        [DataContract]
         class TestClassMember
         {
+            [DataMember(Order = 1)]
             public int Member { get; set; }
 
+            [DataMember(Order = 2)]
             public int Member2 { get; set; }
         }
 
@@ -175,6 +180,22 @@ namespace ImmutableNet.Tests
 
             immutable.Get(x => x.Member).ShouldBe(1);
             immutable.Get(x => x.Member2).ShouldBe(0);
+        }
+
+        [Fact]
+        public void Test_Protobuf_Serialization_Round_Trip()
+        {
+            var testClass = new Immutable<TestClassMember>();
+            testClass = testClass.Modify(x => x.Member = 1);
+
+            var stream = new MemoryStream();
+            Serializer.Serialize(stream, testClass);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var deserialized = Serializer.Deserialize<Immutable<TestClassMember>>(stream);
+
+            deserialized.Get(x => x.Member).ShouldBe(1);
+            deserialized.Get(x => x.Member2).ShouldBe(0);
         }
     }
 }


### PR DESCRIPTION
Added ability to use JSON.Net serialization with older versions and multi-targeted the packages. Fixed an issue that was preventing protobuf-net from serializing properly.