### PR TITLE
Issue 17 - Clone enclosed instance on Get

### DIFF
--- a/src/ImmutableDotNet/ImmutableDotNet.csproj
+++ b/src/ImmutableDotNet/ImmutableDotNet.csproj
@@ -11,7 +11,7 @@
     <Copyright>Apache 2.0</Copyright>
     <PackageProjectUrl>https://github.com/mattnischan/Immutable.Net</PackageProjectUrl>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0.html</PackageLicenseUrl>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ImmutableDotNet/Immutable`T.cs
+++ b/src/ImmutableDotNet/Immutable`T.cs
@@ -121,6 +121,24 @@ namespace ImmutableNet
         }
 
         /// <summary>
+        /// Gets a value from the Immutable. If the value is the enclosed instance, a clone
+        /// of the enclosed instance will be returned.
+        /// </summary>
+        /// <typeparam name="TReturn">The type of the value to return.</typeparam>
+        /// <param name="accessor">A lambda containing the member to return.</param>
+        /// <returns>A value from the provided member.</returns>
+        public T Get(Func<T, T> accessor)
+        {
+            var returnValue = accessor(_self);
+            if(returnValue != null && returnValue.Equals(_self))
+            {
+                return Clone();
+            }
+
+            return returnValue;
+        }
+
+        /// <summary>
         /// Creates a builder instance of the Immutable.
         /// </summary>
         /// <returns>A builder instance.</returns>

--- a/tests/ImmutableDotNet.Tests/ImmutableTests.cs
+++ b/tests/ImmutableDotNet.Tests/ImmutableTests.cs
@@ -110,6 +110,18 @@ namespace ImmutableNet.Tests
         }
 
         [Fact]
+        public void Test_That_Getting_Self_Returns_Clone()
+        {
+            var testClass = new Immutable<TestClass>();
+            testClass = testClass.Modify(x => x.Test = 5);
+
+            var self = testClass.Get(x => x);
+            self.Test = 6;
+
+            testClass.Get(x => x.Test).ShouldNotBe(self.Test);
+        }
+
+        [Fact]
         public void Test_That_Builder_Modifies_Original_Instance()
         {
             var testClass = (new Immutable<TestClass>()).ToBuilder();


### PR DESCRIPTION
Addresses #17. Fix longstanding issue where using Get to return the enclosed instance gives you the actual enclosed instance, which can then be mutated.